### PR TITLE
Add "venue" element to doc metadata

### DIFF
--- a/draft-fossati-tls-attestation.md
+++ b/draft-fossati-tls-attestation.md
@@ -22,6 +22,9 @@ pi:
   text-list-symbols: -o*+
   docmapping: yes
 
+venue:
+  github: yaronf/draft-tls-attestation
+
 author:
  -
        ins: H. Tschofenig


### PR DESCRIPTION
The "venue" metadata is documented [here](https://github.com/cabo/kramdown-rfc/wiki/Syntax2#venue).

Closes #4 .