### PR TITLE
refactor abstract, intro and overview to make it tighter

### DIFF
--- a/draft-fossati-tls-attestation.md
+++ b/draft-fossati-tls-attestation.md
@@ -64,6 +64,7 @@ informative:
   RFC9334: rats-arch
   I-D.ietf-rats-eat: rats-eat
   I-D.ietf-rats-ar4si: rats-ar4si
+  I-D.ietf-teep-architecture: teep-arch
   TPM1.2:
     target: https://trustedcomputinggroup.org/resource/tpm-main-specification/
     title: TPM Main Specification Level 2 Version 1.2, Revision 116

--- a/draft-fossati-tls-attestation.md
+++ b/draft-fossati-tls-attestation.md
@@ -125,7 +125,7 @@ These extensions have been designed to allow the peers to use any attestation te
 
 #  Introduction
 
-Attestation is the process by which an entity produces evidence about itself that another party can use to evaluate the trustworthiness of that entity.
+Attestation {{-rats-arch}} is the process by which an entity produces evidence about itself that another party can use to evaluate the trustworthiness of that entity.
 This document describes a series of protocol extensions to the TLS 1.3 handshake that enables the binding of the TLS authentication key to a remote attestation session.
 As a result, a peer can use "attestation credentials", consisting of compound platform evidence and key attestation, to authenticate itself to its peer during the setup of the TLS channel.
 This enables an attester, such as a confidential workload running in a Trusted Execution Environment (TEE), or an IoT device that is trying to authenticate itself to a network access point, to present a more comprehensive set of security metrics to its peer.

--- a/draft-fossati-tls-attestation.md
+++ b/draft-fossati-tls-attestation.md
@@ -129,7 +129,7 @@ These extensions have been designed to allow the peers to use any attestation te
 Attestation {{-rats-arch}} is the process by which an entity produces evidence about itself that another party can use to evaluate the trustworthiness of that entity.
 This document describes a series of protocol extensions to the TLS 1.3 handshake that enables the binding of the TLS authentication key to a remote attestation session.
 As a result, a peer can use "attestation credentials", consisting of compound platform evidence and key attestation, to authenticate itself to its peer during the setup of the TLS channel.
-This enables an attester, such as a confidential workload running in a Trusted Execution Environment (TEE), or an IoT device that is trying to authenticate itself to a network access point, to present a more comprehensive set of security metrics to its peer.
+This enables an attester, such as a confidential workload running in a Trusted Execution Environment (TEE) {{-teep-arch}}, or an IoT device that is trying to authenticate itself to a network access point, to present a more comprehensive set of security metrics to its peer.
 This, in turn, allows for the implementation of authorization policies at the relying parties that are based on stronger security signals.
 
 Given the variety of deployed and emerging attestation technologies (e.g., {{TPM1.2}}, {{TPM2.0}}, {{-rats-eat}}) these extensions have been explicitly designed to be agnostic of the attestation formats.

--- a/draft-fossati-tls-attestation.md
+++ b/draft-fossati-tls-attestation.md
@@ -118,7 +118,7 @@ The TLS handshake protocol allows authentication of one or both peers using stat
 In some cases, it is also desirable to ensure that the peer runtime environment is in a secure state.
 Attestation is the process by which an entity produces evidence about itself that another party can use to appraise whether that entity is found in a secure state.
 This document describes a series of protocol extensions to the TLS 1.3 handshake that enables the binding of the TLS authentication key to a remote attestation session.
-This enables an attester, such as a confidential workload running in a Trusted Execution Environment (TEE), or an IoT device that is trying to authenticate itself to a network access point, to present a more comprehensive set of security metrics to its peer.
+This enables such an entity, for example, a confidential workload running in a Trusted Execution Environment (TEE), or an IoT device that is trying to authenticate itself to a network access point, to present a more comprehensive set of security metrics to its peer.
 These extensions have been designed to allow the peers to use any attestation technology, in any remote attestation topology, and mutually.
 
 --- middle

--- a/draft-fossati-tls-attestation.md
+++ b/draft-fossati-tls-attestation.md
@@ -118,7 +118,7 @@ The TLS handshake protocol allows authentication of one or both peers using stat
 In some cases, it is also desirable to ensure that the peer runtime environment is in a secure state.
 Attestation is the process by which an entity produces evidence about itself that another party can use to appraise whether that entity is found in a secure state.
 This document describes a series of protocol extensions to the TLS 1.3 handshake that enables the binding of the TLS authentication key to a remote attestation session.
-This enables such an entity, for example, a confidential workload running in a Trusted Execution Environment (TEE), or an IoT device that is trying to authenticate itself to a network access point, to present a more comprehensive set of security metrics to its peer.
+This enables an entity capable of producing attestation evidence, such as a confidential workload running in a Trusted Execution Environment (TEE), or an IoT device that is trying to authenticate itself to a network access point, to present a more comprehensive set of security metrics to its peer.
 These extensions have been designed to allow the peers to use any attestation technology, in any remote attestation topology, and mutually.
 
 --- middle

--- a/draft-fossati-tls-attestation.md
+++ b/draft-fossati-tls-attestation.md
@@ -117,7 +117,7 @@ informative:
 
 The TLS handshake protocol allows authentication of one or both peers using static, long-term credentials.
 In some cases, it is also desirable to ensure that the peer runtime environment is in a secure state.
-Attestation is the process by which an entity produces evidence about itself that another party can use to appraise whether that entity is found in a secure state.
+Such an assurance can be achieved using attestation which is a process by which an entity produces evidence about itself that another party can use to appraise whether that entity is found in a secure state.
 This document describes a series of protocol extensions to the TLS 1.3 handshake that enables the binding of the TLS authentication key to a remote attestation session.
 This enables an entity capable of producing attestation evidence, such as a confidential workload running in a Trusted Execution Environment (TEE), or an IoT device that is trying to authenticate itself to a network access point, to present a more comprehensive set of security metrics to its peer.
 These extensions have been designed to allow the peers to use any attestation technology, in any remote attestation topology, and mutually.

--- a/draft-fossati-tls-attestation.md
+++ b/draft-fossati-tls-attestation.md
@@ -114,11 +114,11 @@ informative:
 
 --- abstract
 
+The TLS handshake protocol allows authentication of one or both peers using static, long-term credentials.
+In some cases, it is also desirable to ensure that the peer runtime environment is in a secure state.
 Attestation is the process by which an entity produces evidence about itself that another party can use to evaluate the trustworthiness of that entity.
 This document describes a series of protocol extensions to the TLS 1.3 handshake that enables the binding of the TLS authentication key to a remote attestation session.
-As a result, a peer can use "attestation credentials" to authenticate itself to its peer during the setup of the TLS channel.
 This enables an attester, such as a confidential workload running in a Trusted Execution Environment (TEE), or an IoT device that is trying to authenticate itself to a network access point, to present a more comprehensive set of security metrics to its peer.
-This, in turn, allows for the implementation of authorization policies at the relying parties that are based on stronger security signals.
 These extensions have been designed to allow the peers to use any attestation technology, in any remote attestation topology, and mutually.
 
 --- middle

--- a/draft-fossati-tls-attestation.md
+++ b/draft-fossati-tls-attestation.md
@@ -133,6 +133,7 @@ This, in turn, allows for the implementation of authorization policies at the re
 
 Given the variety of deployed and emerging attestation technologies (e.g., {{TPM1.2}}, {{TPM2.0}}, {{-rats-eat}}) these extensions have been explicitly designed to be agnostic of the attestation formats.
 This is achieved by reusing the generic encapsulation defined in {{-cmw}} for transporting evidence and attestation result payloads in the TLS Certificate message.
+
 The proposed design supports both background-check and passport topologies, as described in {{Sections 5.2 and 5.1 of -rats-arch}}.
 This is detailed in {{evidence-extensions}} and {{attestation-results-extensions}}.
 This specification provides both one-way (server-only) and mutual (client and server) authentication using attestation credentials, and allows the attestation topologies at each peer to be independent of each other.

--- a/draft-fossati-tls-attestation.md
+++ b/draft-fossati-tls-attestation.md
@@ -116,7 +116,7 @@ informative:
 
 The TLS handshake protocol allows authentication of one or both peers using static, long-term credentials.
 In some cases, it is also desirable to ensure that the peer runtime environment is in a secure state.
-Attestation is the process by which an entity produces evidence about itself that another party can use to evaluate the trustworthiness of that entity.
+Attestation is the process by which an entity produces evidence about itself that another party can use to appraise whether that entity is found in a secure state.
 This document describes a series of protocol extensions to the TLS 1.3 handshake that enables the binding of the TLS authentication key to a remote attestation session.
 This enables an attester, such as a confidential workload running in a Trusted Execution Environment (TEE), or an IoT device that is trying to authenticate itself to a network access point, to present a more comprehensive set of security metrics to its peer.
 These extensions have been designed to allow the peers to use any attestation technology, in any remote attestation topology, and mutually.


### PR DESCRIPTION
I started with #20 but then I realised it couldn't be done in isolation.

I have reorganised a bit the material moving content from abstract/intro/overview around to paint a (slightly more) coherent picture.

Fix #20