### PR TITLE
Fix typo in CCC use case section

### DIFF
--- a/draft-fossati-tls-attestation.md
+++ b/draft-fossati-tls-attestation.md
@@ -815,7 +815,7 @@ including anti-money laundering, drug development in healthcare, contact
 tracing in pandemic times, etc.
 
 In such scenarios, the users (e.g., the party providing the data input for the
-computation, the consumer of the computed attestation results, the party
+computation, the party consuming the computed results, or the party
 providing a proprietary ML model used in the computation) have two goals:
 
 - Identifying the workload they are interacting with,

--- a/draft-fossati-tls-attestation.md
+++ b/draft-fossati-tls-attestation.md
@@ -816,7 +816,7 @@ tracing in pandemic times, etc.
 
 In such scenarios, the users (e.g., the party providing the data input for the
 computation, the party consuming the computed results, or the party
-providing a proprietary ML model used in the computation) have two goals:
+providing a proprietary Machine Learning (ML) model used in the computation) have two goals:
 
 - Identifying the workload they are interacting with,
 - Making sure that the platform on which the workload executes is a

--- a/draft-fossati-tls-attestation.md
+++ b/draft-fossati-tls-attestation.md
@@ -812,11 +812,11 @@ In this example, a confidential workload is executed on computational
 resources hosted at a cloud service provider.  This is a typical
 scenario for secure, privacy-preserving multiparty computation,
 including anti-money laundering, drug development in healthcare, contact
-tracing in pandemic times, etc.
+tracing in pandemic times, Machine Learning (ML) model training, etc.
 
 In such scenarios, the users (e.g., the party providing the data input for the
 computation, the party consuming the computed results, or the party
-providing a proprietary Machine Learning (ML) model used in the computation) have two goals:
+providing a proprietary ML model used in the computation) have two goals:
 
 - Identifying the workload they are interacting with,
 - Making sure that the platform on which the workload executes is a


### PR DESCRIPTION
Fix a typo in the description: it's not the consumer of the attestation results but the consumer of the results of the confidential computation that we are concerned with here.